### PR TITLE
Updated to 1.3

### DIFF
--- a/EldritchArcana/FavoredClassBonus.cs
+++ b/EldritchArcana/FavoredClassBonus.cs
@@ -473,33 +473,9 @@ namespace EldritchArcana
         }
     }
 
-    [Harmony12.HarmonyPatch(typeof(UIUtility), "GetPrerequisiteObject", new Type[] { typeof(Prerequisite) })]
-    static class UIUtility_GetPrerequisiteObject_Patch
-    {
-        static bool Prefix(Prerequisite prerequisite, ref string __result)
-        {
-            try
-            {
-                var custom = prerequisite as CustomPrerequisite;
-                if (custom != null)
-                {
-                    __result = custom.GetCaption();
-                    return false;
-                }
-            }
-            catch (Exception e)
-            {
-                Log.Error(e);
-            }
-            return true;
-        }
-    }
-
     public abstract class CustomPrerequisite : Prerequisite
     {
-        public abstract String GetCaption();
-
-        static CustomPrerequisite() => Main.ApplyPatch(typeof(UIUtility_GetPrerequisiteObject_Patch), "Text for new kinds of prerequisites");
+        // can probably be removed
     }
 
     [AllowMultipleComponents]
@@ -522,7 +498,7 @@ namespace EldritchArcana
             return unit.GetSpellbook(CharacterClass)?.MaxSpellLevel >= RequiredSpellLevel;
         }
 
-        public override String GetCaption() => $"Can cast {CharacterClass.Name} spells of level: {RequiredSpellLevel}";
+        public override String GetUIText() => $"Can cast {CharacterClass.Name} spells of level: {RequiredSpellLevel}";
     }
 
     [AllowedOn(typeof(BlueprintUnitFact))]

--- a/EldritchArcana/Feats/MagicFeats.cs
+++ b/EldritchArcana/Feats/MagicFeats.cs
@@ -975,7 +975,7 @@ namespace EldritchArcana
             return unit.Progression.CharacterLevel == Level;
         }
 
-        public override string GetCaption() => $"{UIStrings.Instance.Tooltips.CharacterLevel} equals: {Level}";
+        public override string GetUIText() => $"{UIStrings.Instance.Tooltips.CharacterLevel} equals: {Level}";
     }
 
     // Used when we need to prevent metamagic from increasing cast time.

--- a/EldritchArcana/Helpers.cs
+++ b/EldritchArcana/Helpers.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Numerics;
 using System.Reflection;
 using System.Text;
 using Kingmaker;
@@ -62,6 +61,98 @@ using static Kingmaker.UnitLogic.Commands.Base.UnitCommand;
 
 namespace EldritchArcana
 {
+    // limited implementation of BigInteger to deal with removal of Numerics
+    class BigInteger {
+        Byte[] bytes = null;
+        bool neg = false;
+
+        static readonly String allowedchars = "0123456789abcdef";
+
+        public int Length() { return (bytes == null) ? 0 : bytes.Length; }
+
+        // parses a string, but fails for anything that isn't a hexstring
+        public static BigInteger Parse(String str, NumberStyles ignoredStyle) {
+            if (ignoredStyle != NumberStyles.HexNumber) throw new NotImplementedException("Non hex styles are not implemented!");
+            var biggie = new BigInteger();
+            // trim leading zeroes, but make sure we have an even number of chars
+            var charBase = str.Trim().ToLower();
+            if (charBase.Length != 0 && allowedchars.IndexOf(charBase[0]) >= 8) biggie.neg = true;
+            charBase = charBase.TrimStart('0');
+            if (charBase.Length % 2 != 0) charBase = charBase.Insert(0, biggie.neg ? "f" : "0");
+            // let's make it a char array
+            var chars = charBase.ToCharArray();
+            // byte array length is div 2 because 00..FF can fit into 1 byte
+            int length = (chars.Length / 2);
+            if (length != 0) {
+                biggie.bytes = new Byte[length];
+                int current = 0; // buffer for current byte
+                for (int i = 0; i < chars.Length; ++i) {
+                    int next = allowedchars.IndexOf(chars[i]);
+                    if (next == -1) throw new FormatException("this is not a hex string!");
+                    if (i % 2 == 0) {
+                        current = next;
+                    } else {
+                        biggie.bytes[i / 2] = (byte)(current * 16 + next);
+                    }
+                }
+            }
+            return biggie;
+        }
+
+        // doesn't actually parse, but should cover the usage in EA
+        public static bool TryParse(String input, out BigInteger result) {
+            String numericchars = "0123456789";
+            result = new BigInteger();
+            return !input.Trim().ToCharArray().Any(c => { return numericchars.IndexOf(c) == -1; });
+        }
+
+        public static BigInteger operator ^(BigInteger a, BigInteger b) {
+            if (a.bytes == null) return b;
+            if (b.bytes == null) return a;
+            var c = new BigInteger();
+            c.neg = a.neg != b.neg;
+            if (a.Length() < b.Length()) {
+                int l = b.Length();
+                int o = l - a.Length();
+                c.bytes = new byte[l];
+                Array.Copy(b.bytes, c.bytes, l);
+                for (int i = 0; i < o; ++i) { c.bytes[i] = 255; }
+                for (int i = 0; i < a.Length(); ++i) {
+                    c.bytes[i + o] ^= a.bytes[i];
+                }
+            } else {
+                int l = a.Length();
+                int o = l - b.Length();
+                c.bytes = new byte[l];
+                Array.Copy(a.bytes, c.bytes, l);
+                for (int i = 0; i < o; ++i) { c.bytes[i] = 255; }
+                for (int i = 0; i < b.Length(); ++i) {
+                    c.bytes[i + o] ^= b.bytes[i];
+                }
+            }
+            return c;
+        }
+
+        public String ToString(String ignore) {
+            if (ignore != "x32") throw new NotImplementedException("Non x32 styles are not implemented!");
+            StringBuilder retStr = new StringBuilder(32);
+            int bLength = (bytes == null) ? 0 : bytes.Length * 2;
+            if (bLength < 32) { retStr.Append(neg ? 'f' : '0', 32 - bLength); };
+            if (bytes != null) {
+                Array.ForEach(bytes, b => { retStr.Append(b.ToString("x2")); });
+            }
+            var str = retStr.ToString();
+            if (!neg && allowedchars.IndexOf(str[0]) >= 8) str = "0" + str;
+            if (neg) {
+                while (str.Length > 32 && allowedchars.IndexOf(str[1]) >= 8 && str[0] == 'f') {
+                    str = str.Substring(1);
+                }
+            }
+            return str;
+        }
+    }
+
+
     // A few notes discovered while debugging issues:
     //
     // - don't import Harmony12, ever! It has an extension method called "Add" that can

--- a/EldritchArcana/Main.cs
+++ b/EldritchArcana/Main.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Numerics;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;

--- a/EldritchArcana/Prestige/ArcaneSavant.cs
+++ b/EldritchArcana/Prestige/ArcaneSavant.cs
@@ -264,9 +264,9 @@ namespace EldritchArcana
 
         public override void OnEventAboutToTrigger(RuleSkillCheck evt)
         {
-            if (evt.StatType == StatType.SkillPerception && evt.Reason.TriggerEntity is TrapObjectView.TrapObjectData)
+            if (evt.StatType == StatType.SkillPerception && evt.Reason.SourceEntity is TrapObjectView.TrapObjectData)
             {
-                Log.Write($"{GetType().Name} use {Skill} for finding trap {evt.Reason.TriggerEntity}");
+                Log.Write($"{GetType().Name} use {Skill} for finding trap {evt.Reason.SourceEntity}");
                 Helpers.SetField(evt, "StatType", Skill);
             }
         }

--- a/EldritchArcana/Sorcerer/Crossblooded.cs
+++ b/EldritchArcana/Sorcerer/Crossblooded.cs
@@ -20,6 +20,7 @@ using Kingmaker.UnitLogic.Class.LevelUp;
 using Kingmaker.UnitLogic.Class.LevelUp.Actions;
 using Kingmaker.UnitLogic.FactLogic;
 using Kingmaker.Utility;
+using Kingmaker.EntitySystem.Entities;
 
 namespace EldritchArcana
 {
@@ -587,10 +588,10 @@ namespace EldritchArcana
             return Not;
         }
 
-        public override String GetCaption() => Not ? $"Doesn't know spell: {Spell.Name}" : $"Knows spell: {Spell.Name}";
+        public override String GetUIText() => Not ? $"Doesn't know spell: {Spell.Name}" : $"Knows spell: {Spell.Name}";
     }
 
-    [Harmony12.HarmonyPatch(typeof(UIUtilityUnit), "CollectClassDeterminator", typeof(BlueprintProgression), typeof(UnitProgressionData))]
+    [Harmony12.HarmonyPatch(typeof(UIUtilityUnit), "CollectClassDeterminator", typeof(UnitEntityData), typeof(Spellbook))]//typeof(BlueprintProgression), typeof(UnitProgressionData))]
     static class UIUtilityUnit_CollectClassDeterminators_Patch
     {
         // This method is only used by `SpellBookView.SetupHeader()` to find information such
@@ -598,11 +599,11 @@ namespace EldritchArcana
         //
         // Unfortunately, it doesn't understand how to find data from the archetype.
         // So this patch addresses it.
-        static void Postfix(BlueprintProgression progression, UnitProgressionData progressionData, ref List<BlueprintFeatureBase> __result)
-        {
+        static void Postfix(UnitEntityData unit, Spellbook spellbook, ref List<BlueprintFeatureBase> __result) {
             try
             {
-                var @class = Helpers.classes.FirstOrDefault(c => c.Progression == progression);
+                var progressionData = unit.Descriptor.Progression;
+                var @class = spellbook.Blueprint.CharacterClass;
                 if (@class == null) return;
 
                 var list = __result ?? new List<BlueprintFeatureBase>();
@@ -647,6 +648,7 @@ namespace EldritchArcana
                 case FeatureGroup.BloodLine:
                 case FeatureGroup.MagusArcana:
                 case FeatureGroup.EldritchScionArcana:
+                case FeatureGroup.ThassilonianSpellbook:
                 case FeatureGroup.DraconicBloodlineSelection:
                 case FeatureGroup.BlightDruidDomain:
                 case FeatureGroup.ClericSecondaryDomain:

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-slate


### PR DESCRIPTION
Hi,

I took the liberty of making a pull request for this.

It should fix the mod for 1.3.
- fixed the crossblooded icon (I think)
- removed patch that is no longer needed, and renamed GetCaption to GetUIText
- Added a custom BigInteger replacement for the now removed System.Numerics. It covers the use cases you used in the mod, which should maintain backwards compatibility
- renamed TriggerEntity to SourceEntity

Did some testing. I was able to make a new character and load an existing game. No errors as far as I can tell.