### PR TITLE
Enable athiest oracles

### DIFF
--- a/EldritchArcana/Oracle/Oracle.cs
+++ b/EldritchArcana/Oracle/Oracle.cs
@@ -106,8 +106,8 @@ namespace EldritchArcana
             oracle.MaleEquipmentEntities = cleric.MaleEquipmentEntities;
             oracle.FemaleEquipmentEntities = cleric.FemaleEquipmentEntities;
 
-            // Both of the restrictions here are relevant (no atheism feature, no animal class).
-            oracle.ComponentsArray = cleric.ComponentsArray;
+            // Only the cleric restriction no animal class is relevant here, use sorcerer's instead
+            oracle.ComponentsArray = sorcerer.ComponentsArray;
             oracle.StartingItems = cleric.StartingItems;
 
             var progression = Helpers.CreateProgression("OracleProgression",


### PR DESCRIPTION
Oracles should be able to be athiests, they are described as:

> Although the gods work through many agents, perhaps none is more mysterious than the oracle. These divine vessels are granted power without their choice, selected by providence to wield powers that even they do not fully understand. Unlike a cleric, who draws her magic through devotion to a deity, oracles garner strength and power from many sources, namely those patron deities who support their ideals. Instead of worshiping a single source, oracles tend to venerate all of the gods that share their beliefs. While some see the powers of the oracle as a gift, others view them as a curse, changing the life of the chosen in unforeseen ways.

 not requiring devotion or consent to receive their powers. The pathfinder [iconic oracle](https://pathfinder.fandom.com/wiki/Alahazra) is even an atheist.